### PR TITLE
[IMP] web_disable_export_group: cfg settings

### DIFF
--- a/web_disable_export_group/README.rst
+++ b/web_disable_export_group/README.rst
@@ -23,13 +23,15 @@ Web Disable Export Group
     :target: https://runbot.odoo-community.org/runbot/162/12.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 In the standard Odoo the UI option 'Export' that is present in the 'Action' menu
 of any list view is always enabled (for every user).
 
 This module makes the option 'Export' enabled only for the users that belong
 to the Export Data group.
+
+By Default This feature is disabled. When module is installed, you must also check option 'Enable Export Hide option' in general settings.
 
 Admin user can always use the export option.
 

--- a/web_disable_export_group/__manifest__.py
+++ b/web_disable_export_group/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Web Disable Export Group',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'license': 'AGPL-3',
     'author': 'Onestein, '
               'Tecnativa, '
@@ -11,11 +11,12 @@
     'website': 'https://github.com/OCA/web',
     'category': 'Web',
     'depends': [
-        'web',
+        'base_setup',
     ],
     'data': [
         'security/groups.xml',
         'templates/assets.xml',
+        'views/res_config_settings_views.xml',
     ],
     'installable': True,
 }

--- a/web_disable_export_group/migrations/12.0.1.1.0/post-migration.py
+++ b/web_disable_export_group/migrations/12.0.1.1.0/post-migration.py
@@ -1,0 +1,13 @@
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    """Post migrate web_disable_export_group.
+
+    Enable export hide option, because it was expected to be enabled
+    before this change.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env.ref('base.group_user').implied_ids = [
+        (4, env.ref('web_disable_export_group.export_group_toggle').id)
+    ]

--- a/web_disable_export_group/models/__init__.py
+++ b/web_disable_export_group/models/__init__.py
@@ -1,1 +1,1 @@
-from . import ir_http
+from . import ir_http, res_config_settings

--- a/web_disable_export_group/models/ir_http.py
+++ b/web_disable_export_group/models/ir_http.py
@@ -1,18 +1,26 @@
 # Copyright 2018 Tecnativa - David Vidal
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from odoo import models, api
 from odoo.http import request
 
 
 class Http(models.AbstractModel):
     _inherit = 'ir.http'
 
+    @api.model
+    def _can_export_data(self, user):
+        if user:
+            # If option disabled, then anyone can export.
+            if not user.has_group(
+                    'web_disable_export_group.export_group_toggle'):
+                return True
+            return user.has_group(
+                'web_disable_export_group.group_export_data')
+        return False
+
     def session_info(self):
         res = super(Http, self).session_info()
         user = request.env.user
-        res.update({
-            'group_export_data': user and user.has_group(
-                'web_disable_export_group.group_export_data'),
-        })
+        res['group_export_data'] = self._can_export_data(user)
         return res

--- a/web_disable_export_group/models/res_config_settings.py
+++ b/web_disable_export_group/models/res_config_settings.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    """Extend to enable/disable export button visibility option."""
+
+    _inherit = 'res.config.settings'
+
+    group_export_toggle = fields.Boolean(
+        string="Enable Export Hide option",
+        implied_group='web_disable_export_group.export_group_toggle'
+    )

--- a/web_disable_export_group/security/groups.xml
+++ b/web_disable_export_group/security/groups.xml
@@ -8,4 +8,9 @@
         <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
     </record>
 
+    <record id="export_group_toggle" model="res.groups">
+        <field name="name">Enable Export Hide option</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+    </record>
+
 </odoo>

--- a/web_disable_export_group/tests/test_disable_export_group.py
+++ b/web_disable_export_group/tests/test_disable_export_group.py
@@ -8,18 +8,29 @@ from odoo.tests.common import SavepointCase
 
 
 class TestDisableExportGroup(SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Enable export hide option."""
+        super().setUpClass()
+        cls.env.ref('base.group_user').implied_ids = [
+            (4, cls.env.ref('web_disable_export_group.export_group_toggle').id)
+        ]
+
     @patch('odoo.addons.base_setup.models.ir_http.request')
     @patch('odoo.addons.web_disable_export_group.models.ir_http.request')
     @patch('odoo.addons.web.models.ir_http.request')
     @patch('odoo.addons.web_tour.models.ir_http.request')
     @patch('odoo.addons.web_dashboard.models.ir_http.request')
+    @patch('odoo.addons.web_enterprise.models.ir_http.request')
     def test_session_info(
-            self, request, request1, request2, request3, request4):
+            self, request, request1, request2, request3, request4, request5):
         request.env = self.env
         request1.env = self.env
         request2.env = self.env
         request3.env = self.env
         request4.env = self.env
+        request5.env = self.env
         session_info = self.env['ir.http'].session_info()
         self.assertTrue(session_info['group_export_data'])
 
@@ -28,8 +39,9 @@ class TestDisableExportGroup(SavepointCase):
     @patch('odoo.addons.web.models.ir_http.request')
     @patch('odoo.addons.web_tour.models.ir_http.request')
     @patch('odoo.addons.web_dashboard.models.ir_http.request')
+    @patch('odoo.addons.web_enterprise.models.ir_http.request')
     def test_session_info_not_allowed(
-            self, request, request1, request2, request3, request4):
+            self, request, request1, request2, request3, request4, request5):
         demo_env = Environment(
             self.env.cr,
             self.env.ref('base.default_user').id,
@@ -40,5 +52,6 @@ class TestDisableExportGroup(SavepointCase):
         request2.env = demo_env
         request3.env = demo_env
         request4.env = demo_env
+        request5.env = demo_env
         session_info = demo_env['ir.http'].session_info()
         self.assertFalse(session_info['group_export_data'])

--- a/web_disable_export_group/views/res_config_settings_views.xml
+++ b/web_disable_export_group/views/res_config_settings_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form_inherit" model="ir.ui.view">
+        <field name="name">res.config.settings.form.export.toggle</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <div id="access_rights" position="after">
+                <div id="export_toggle" class="col-12 col-lg-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                        <field name="group_export_toggle"/>
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="group_export_toggle"/>
+                        <div class="text-muted">
+                            Enable Export Button Hide option per user.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Adding config settings so it would be more flexible. It is now possible
to enable/disable hide option without modifying who belongs to export
data group.

Also this make it not intrusive on JS side, where tests are very
sensitive and will fail, if it detects any change.